### PR TITLE
Updating Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,59 +4,12 @@
     <h1 align="center"> Packet Documentation </h1>
 </p>
 
-<!--- Badges --->
-<p align="center">
-    <a href="https://github.com/packethost/docs/watchers">
-        <img src="https://img.shields.io/github/watchers/packethost/docs?color=success" alt="Watchers"/>
-    </a>
-    <a href="https://github.com/packethost/docs/network/members">
-        <img src="https://img.shields.io/github/forks/packethost/docs?color=success" alt="Forks"/>
-    </a>
-    <a href="https://github.com/packethost/docs/graphs/contributors">
-        <img src="https://img.shields.io/github/contributors/packethost/docs?color=success" alt="Contributors"/>
-    </a>
-    <a href="https://github.com/packethost/docs/blob/master/LICENSE.md">
-        <img src="https://img.shields.io/github/license/packethost/docs?color=success" alt="License"/>
-    </a>
-    <a href="https://cloud.drone.io/packethost/docs">
-        <img src="https://img.shields.io/drone/build/packethost/docs" alt="License"/>
-    </a>
-    <a href="https://github.com/packethost/standards/blob/master/maintained-statement.md">
-        <img src="https://img.shields.io/badge/Stability-Maintained-green.svg" alt="Stability"/>
-    </a>
-</p>
-
 <!--- Headline Description --->
-This is the public documentation for Packet's public services.
-View our documentation page at [Packet Docs](https://www.packet.com/developers/).
+This is the archive of public documentation for Packet's public services, before it rebranded as Equinix Metal.
 
-This repository is [Maintained](https://github.com/packethost/standards/blob/master/maintained-statement.md) meaning that this software is supported by Packet and its community - available to use in production environments.
+This repository is [End of Life](https://github.com/equinix-labs/equinix-labs/blob/main/end-of-life-statement.md) This repository is End of Life meaning that it is no longer supported nor maintained by Equinix Metal or its community.
 
-<!--- What We Have Here --->
-## What We Have Here
+<!--- Current Documentation and Technical Guides --->
+## Current Documentation and Technical Guides
 
-- [Guides](https://github.com/packethost/docs/tree/master/guides)
-- [Libraries](https://github.com/packethost/docs/tree/master/libraries)
-- [Integrations](https://github.com/packethost/docs/tree/master/integrations)
-- [Network](https://github.com/packethost/docs/tree/master/products/04-network)
-- [Products](https://github.com/packethost/docs/tree/master/products)
-
-<!--- How To Contribute --->
-## How To Contribute
-
-Please review our [contributing standards](https://github.com/packethost/docs/blob/master/standards.md). Then feel free to submit pull request.
-
-<!--- Issues --->
-## Issues
-
-Please, feel free to open a new issue.
-
-<!--- License --->
-## License
-
-The Packet Documentation is an open source project under the [MIT License](https://github.com/packethost/docs/blob/adding-readme/LICENSE.md).
-
-<!--- Reach out --->
-## Reach Out
-
-We would love to hear from you! If you have any questions not covered here, please reach us out at support@packet.com.
+The current Equinix Metal product documentation is available at https://metal.equinix.com/developers/docs/. The current home of the Technical Guides is https://metal.equinix.com/developers/guides/.


### PR DESCRIPTION
Marking repo as end-of-life as it has not had activity in the past few months, the docs and guides are now maintained internally, and the content here is out of date.

Added End of Life statement and links to current Equinix Metal documentation and guides.